### PR TITLE
build-docker

### DIFF
--- a/.github/workflows/detect-and-trigger.yml
+++ b/.github/workflows/detect-and-trigger.yml
@@ -22,7 +22,7 @@ name: detect-and-trigger
 on:
   push:
     branches:
-      - '*autobuild*'  # Only trigger if the branch name contains "autobuild"
+      - '**autobuild**'  # Only trigger if the branch name contains "autobuild"
     paths:
       - '**/Dockerfile.*'  # Only trigger if a Dockerfile.* is modified in any directory
 


### PR DESCRIPTION
fix: two asterisks may be needed for correct interpretation