### PR TITLE
ci: trigger autobuild for testing

### DIFF
--- a/base_images/ccbr_ubuntu_20.04/Dockerfile.v8
+++ b/base_images/ccbr_ubuntu_20.04/Dockerfile.v8
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 
 LABEL maintainer="Vishal Koparde *(kopardev on GitHub)*"
+
 LABEL github_handle="kopardev"
 
 # Build time variables


### PR DESCRIPTION
Oddly, it isn't running for me on this branch on push. It also didn't work when the branch was named `test-autobuild`. Let's see if opening this PR will trigger it.