### PR TITLE
test: use bash shell when installing quarto with mamba

### DIFF
--- a/tests/base_shell/Dockerfile.v1
+++ b/tests/base_shell/Dockerfile.v1
@@ -22,8 +22,10 @@ RUN apt-get update && apt-get upgrade -y && \
 
 RUN mkdir -p /opt2 /data2
 
+RUN echo $SHELL
 SHELL ["/bin/bash", "-c"]
 RUN chsh -s /bin/bash
+RUN echo $SHELL
 
 # Install conda and give write permissions to conda folder
 RUN echo 'export PATH=/opt2/conda/bin:$PATH' > /etc/profile.d/conda.sh && \

--- a/tests/base_shell/Dockerfile.v1
+++ b/tests/base_shell/Dockerfile.v1
@@ -1,14 +1,26 @@
-FROM nciccbr/ccbr_ubuntu_22.04:v4
+FROM ubuntu:22.04
 
-# build time variables
-ARG BUILD_DATE="000000"
-ENV BUILD_DATE=${BUILD_DATE}
-ARG BUILD_TAG="000000"
-ENV BUILD_TAG=${BUILD_TAG}
-ARG REPONAME="000000"
-ENV REPONAME=${REPONAME}
-ARG DOCKERFILE="Dockerfile"
-ENV DOCKERFILE=${DOCKERFILE}
+# Set environment variables to reduce interactive prompts during installation
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+# Update the package list, install essential packages, and clean up
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        bash build-essential bzip2 ca-certificates cmake coreutils curl figlet \
+        g++ gcc gfortran git libatlas-base-dev libblas-dev libboost-dev \
+        libbz2-dev libcurl4-openssl-dev libexpat1-dev libfreetype6-dev \
+        libgd-dev libgd-perl libgs-dev libgsl-dev libicu-dev libjudy-dev \
+        liblapack-dev liblzma-dev libmysqlclient-dev libncurses-dev \
+        libopenmpi-dev libpng-dev librtmp-dev libssl-dev libtool libxml2-dev \
+        libxslt-dev locales make manpages-dev netbase parallel pigz rsync unzip \
+        vim wget zlib1g zlib1g-dev && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    apt-get autoclean && apt-get autoremove -y && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+RUN mkdir -p /opt2 /data2
 
 SHELL ["/bin/bash", "-c"]
 RUN chsh -s /bin/bash
@@ -20,15 +32,11 @@ RUN echo 'export PATH=/opt2/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     rm ~/miniforge3.sh && chmod 777 -R /opt2/conda/
 ENV PATH="/opt2/conda/bin:$PATH"
 ENV CONDA_ENV=quarto
-RUN mamba create -n ${CONDA_ENV} -c conda-forge -c bioconda quarto
+RUN mamba create -n ${CONDA_ENV} -c conda-forge quarto
 ENV R_LIBS_USER="/opt2/conda/envs/${CONDA_ENV}/lib/R/library/"
 ENV PATH="/opt2/conda/envs/${CONDA_ENV}/bin:$PATH"
 ENV PYTHONPATH="/opt2/conda/envs/${CONDA_ENV}/lib/${CONDA_ENV}/site-packages/"
 RUN quarto check
-
-# Copy Dockerfile and other files in a single layer
-COPY ${DOCKERFILE} /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
-RUN chmod -R a+rx /opt2 && chmod a+r /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
 
 # cleanup
 WORKDIR /data2

--- a/tests/base_shell/Dockerfile.v1
+++ b/tests/base_shell/Dockerfile.v1
@@ -1,0 +1,36 @@
+FROM nciccbr/ccbr_ubuntu_22.04:v4
+
+# build time variables
+ARG BUILD_DATE="000000"
+ENV BUILD_DATE=${BUILD_DATE}
+ARG BUILD_TAG="000000"
+ENV BUILD_TAG=${BUILD_TAG}
+ARG REPONAME="000000"
+ENV REPONAME=${REPONAME}
+ARG DOCKERFILE="Dockerfile"
+ENV DOCKERFILE=${DOCKERFILE}
+
+SHELL ["/bin/bash", "-c"]
+RUN chsh -s /bin/bash
+
+# Install conda and give write permissions to conda folder
+RUN echo 'export PATH=/opt2/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O ~/miniforge3.sh && \
+    /bin/bash ~/miniforge3.sh -b -p /opt2/conda && \
+    rm ~/miniforge3.sh && chmod 777 -R /opt2/conda/
+ENV PATH="/opt2/conda/bin:$PATH"
+ENV CONDA_ENV=quarto
+RUN mamba create -n ${CONDA_ENV} -c conda-forge -c bioconda quarto
+ENV R_LIBS_USER="/opt2/conda/envs/${CONDA_ENV}/lib/R/library/"
+ENV PATH="/opt2/conda/envs/${CONDA_ENV}/bin:$PATH"
+ENV PYTHONPATH="/opt2/conda/envs/${CONDA_ENV}/lib/${CONDA_ENV}/site-packages/"
+RUN quarto check
+
+# Copy Dockerfile and other files in a single layer
+COPY ${DOCKERFILE} /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
+RUN chmod -R a+rx /opt2 && chmod a+r /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
+
+# cleanup
+WORKDIR /data2
+RUN apt-get clean && apt-get purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
testing to see if setting the build shell to bash allows installing quarto via mamba