### PR TITLE
feat: updated shiver dockerfile with more libs and gatk4

### DIFF
--- a/shiver/ccbr_shiver_1.7.3/Dockerfile.v2
+++ b/shiver/ccbr_shiver_1.7.3/Dockerfile.v2
@@ -1,0 +1,65 @@
+FROM nciccbr/ccbr_ubuntu_22.04:v4
+
+ARG BUILD_DATE="000000"
+ENV BUILD_DATE=${BUILD_DATE}
+ARG BUILD_TAG="000000"
+ENV BUILD_TAG=${BUILD_TAG}
+ARG REPONAME="000000"
+ENV REPONAME=${REPONAME}
+ARG DOCKERFILE="Dockerfile"
+ENV DOCKERFILE=${DOCKERFILE}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Miniforge/conda/mamba into /opt2/conda
+RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/miniforge.sh && \
+    /bin/bash /tmp/miniforge.sh -b -p /opt2/conda && \
+    rm -f /tmp/miniforge.sh && \
+    chmod -R a+rx /opt2/conda
+
+ENV PATH="/opt2/conda/bin:$PATH"
+
+RUN conda config --add channels bioconda && \
+    conda config --add channels conda-forge && \
+    conda config --add channels defaults && \
+    conda config --set channel_priority strict && \
+    conda install -n base -y mamba && \
+    conda clean -afy
+
+COPY environment.yml /data2/
+
+RUN mamba env create -n shiver -f /data2/environment.yml && \
+    mamba clean -a -y
+
+ENV PATH="/opt2/conda/envs/shiver/bin:/opt2/conda/bin:$PATH"
+
+RUN cd /data2 && \
+    git clone https://github.com/ChrisHIV/shiver.git && \
+    cp -r shiver/data/example_input test_data && \
+    rm -rf shiver
+
+RUN cd /data2 && \
+    wget -O hxb2_ref.fasta "https://www.ncbi.nlm.nih.gov/sviewer/viewer.fcgi?id=K03455&db=nuccore&report=fasta"
+
+RUN cd /data2 && \
+    echo "Running shiver test..." && \
+    shiver_init.sh my_init_dir /opt2/conda/envs/shiver/bin/config.sh \
+        hxb2_ref.fasta \
+        test_data/adapters_Illumina.fasta \
+        test_data/primers_GallEtAl2012.fasta && \
+    shiver_align_contigs.sh my_init_dir /opt2/conda/envs/shiver/bin/config.sh \
+        test_data/MysteryHIV_contigs.fasta my_output_id && \
+    shiver_map_reads.sh my_init_dir /opt2/conda/envs/shiver/bin/config.sh \
+        test_data/MysteryHIV_contigs.fasta my_output_id \
+        my_output_id.blast my_output_id_cut_wRefs.fasta \
+        test_data/MysteryHIV_1.fastq \
+        test_data/MysteryHIV_2.fastq && \
+    echo "Shiver test completed successfully!" && \
+    ls -la my_output_id*
+
+COPY test_shiver.sh /data2/
+RUN chmod +x /data2/test_shiver.sh
+
+COPY ${DOCKERFILE} /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
+
+WORKDIR /data2

--- a/shiver/ccbr_shiver_1.7.3/environment.yml
+++ b/shiver/ccbr_shiver_1.7.3/environment.yml
@@ -4,12 +4,18 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.13
+  - python=3.10
   - shiver=1.7.3
   - biopython=1.85
-  - numpy=2.3.0
-  - pandas=2.3.0
+  - numpy
+  - pandas
+  - matplotlib
+  - pysam
   - samtools=1.22
+  - bcftools
+  - htslib
+  - gatk4=4.6.2.0
+  - openjdk=17
   - blast=2.16.0
   - mafft=7.526
   - trimmomatic=0.39
@@ -19,9 +25,8 @@ dependencies:
   - entrez-direct=22.4
   - wget=1.21.4
   - curl=8.14.1
-  - openjdk=23.0.2
   - pip=25.1.1
   - pip:
-    - pyfastaq==3.17.0
-    - aiofiles==24.1.0
-    - setuptools==80.9.0
+      - pyfastaq==3.17.0
+      - aiofiles==24.1.0
+      - setuptools==80.9.0

--- a/shiver/ccbr_shiver_1.7.3/v2-dev.README.md
+++ b/shiver/ccbr_shiver_1.7.3/v2-dev.README.md
@@ -1,0 +1,32 @@
+## CCBR/Dockers2 nciccbr/ccbr_shiver_1.7.3:v2-dev
+
+Dockerfile source: https://github.com/CCBR/Dockers2/blob/a06b97d223ffd982149eb1cd7469209a2006c35a/shiver/ccbr_shiver_1.7.3/Dockerfile.v2
+
+
+Built on: 2026-03-19_18:14:38 
+
+Build tag: v2-dev 
+
+Base image: nciccbr/ccbr_ubuntu_22.04:v4 
+
+Dockerfile path in repo: shiver/ccbr_shiver_1.7.3/Dockerfile.v2 
+
+
+| Tool | Version |
+|---------|---------|
+| bcftools | NOTINDOCKER |
+| bedops | 2.4.40 typical |
+| bedtools | v2.30.0 |
+| bowtie | 1.3.1 |
+| bowtie2 | 2.4.4 |
+| bwa | NOTINDOCKER |
+| cutadapt | NOTINDOCKER |
+| git | 2.34.1 |
+| java | 2026-01-20 |
+| multiqc | 1.25.1 |
+| parallel | 20210822 |
+| pigz | 2.6 |
+| python2 | 2.7.18 |
+| python3 | 3.10.20 |
+| samtools | 1.22.1 |
+| vcftools | 0.1.16 |


### PR DESCRIPTION
## Changes

- Uses updated nciccbr base image (nciccbr/ccbr_ubuntu_22.04:v4)
- Replaces reliance on pre-existing mamba/conda in the base image with an explicit Miniforge installation (/opt2/conda)
- Uses mamba for deterministic and faster environment resolution
- Fixes unsatisfiable dependencies by aligning versions required by gatk4 (Python 3.10, OpenJDK 17) and removing incompatible hard pins (e.g., numpy, pandas)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
