### PR TITLE
fix: install spac via git url

### DIFF
--- a/spac/spac-gpu/Dockerfile.v1.0.0
+++ b/spac/spac-gpu/Dockerfile.v1.0.0
@@ -67,17 +67,6 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
  && conda clean -afy
 
 # -----------------------------------------------------------------------------
-# 2. Copy the SCSAWorkflow repo into the image — branch-aware.
-#    Build context must be the repo root so this picks up:
-#      - src/spac/...   (entire SPAC package including new transform/ module)
-#      - setup.py / pyproject.toml
-#      - tools/spac_gpu/{run_gpu.sh, run_grapheno.py, merge_labels.py}
-#    Whatever git branch is checked out becomes the version installed below.
-# -----------------------------------------------------------------------------
-WORKDIR /opt/scsaworkflow
-COPY . .
-
-# -----------------------------------------------------------------------------
 # 3. Install SPAC into BOTH conda envs as an editable install of the
 #    copied tree. Identical to how the CPU Dockerfile installs SPAC, so
 #    the same branch's code is what runs in either container.
@@ -87,25 +76,18 @@ COPY . .
 # -----------------------------------------------------------------------------
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate preprocess && \
-    pip install --no-cache-dir -e . && \
-    pip install --no-cache-dir phenograph
+    pip install --no-cache-dir spac@git+https://github.com/FNLCR-DMAP/SCSAWorkflow@phenograph-gpu-refactor && \
+    pip install --no-cache-dir phenograph # TODO add phenograph to spac dependencies?
 
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate rapids && \
-    pip install --no-cache-dir -e .
+    pip install --no-cache-dir spac@git+https://github.com/FNLCR-DMAP/SCSAWorkflow@phenograph-gpu-refactor
 
 # -----------------------------------------------------------------------------
-# 4. Install the orchestrator and helpers used by the Galaxy GPU XML.
-#    The XML invokes `bash /opt/spac-gpu/run_gpu.sh <params.json>`.
-#    These files live in the repo at tools/spac_gpu/ so they're already
-#    inside /opt/scsaworkflow after step 2 — copy them to a stable path.
+# 4. The orchestrator and helpers used by the Galaxy GPU XML will be specified as scripts in spac's setup.py/pyproject.toml file
+#    The XML should invoke them as scripts in the $PATH, e.g. `bash run_gpu.sh <params.json>`.
 # -----------------------------------------------------------------------------
-RUN mkdir -p /opt/spac-gpu && \
-    cp /opt/scsaworkflow/tools/spac_gpu/run_gpu.sh /opt/spac-gpu/run_gpu.sh && \
-    cp /opt/scsaworkflow/tools/spac_gpu/run_grapheno.py /opt/spac-gpu/run_grapheno.py && \
-    cp /opt/scsaworkflow/tools/spac_gpu/merge_labels.py /opt/spac-gpu/merge_labels.py && \
-    chmod +x /opt/spac-gpu/run_gpu.sh && \
-    ln -s /opt/spac-gpu/run_gpu.sh /usr/local/bin/spac-gpu-run
+RUN which run_gpu.sh
 
 # -----------------------------------------------------------------------------
 # 5. Build-time sanity checks — fail fast if either env is broken.

--- a/spac/spac-gpu/Dockerfile.v1.0.0
+++ b/spac/spac-gpu/Dockerfile.v1.0.0
@@ -146,16 +146,13 @@ RUN git clone --depth 1 --branch "${GITHUB_BRANCH}" \
     rm -rf /tmp/scsa
 
 # -----------------------------------------------------------------------------
-# 4. Build-time sanity checks — fail fast if either env is broken.
+# 4. Build-time sanity checks for the preprocess env.
 #
 #    preprocess env must import anndata + spac.templates.template_utils
 #    + spac.transform.clustering.phenograph.prepare_features
 #    (what stage 1 and stage 3 load).
 #
-#    rapids env: CUDA libs (cuml, cugraph, cudf, cupy) cannot be imported
-#    without a GPU, so we use importlib.util.find_spec() to verify they
-#    are installed without initializing CUDA. SPAC grapheno is also
-#    checked via find_spec since it transitively imports CUDA packages.
+#    The rapids env is NOT exercised via Python here — see section 5.
 # -----------------------------------------------------------------------------
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate preprocess && \
@@ -166,21 +163,50 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
         from spac.templates.template_utils import load_input, parse_params, save_results; \
         print('  preprocess env: SPAC imports OK')"
 
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate rapids && \
-    echo "=== Verifying rapids env ===" && \
-    python -c "import importlib.util; \
-        missing = [m for m in ('cuml','cugraph','cudf','cupy','dask_cuda') \
-                   if importlib.util.find_spec(m) is None]; \
-        assert not missing, f'Missing RAPIDS packages: {missing}'; \
-        print('  rapids env: RAPIDS packages installed')" && \
-    python -c "import importlib.util; \
-        spec = importlib.util.find_spec('spac.transform.clustering.phenograph.gpu.grapheno'); \
-        assert spec is not None, 'grapheno module not found'; \
-        print('  rapids env: SPAC GPU module installed')"
+# -----------------------------------------------------------------------------
+# 5. STRUCTURE / PRESENCE CHECK for the rapids env (NOT a runtime
+#    validation of RAPIDS itself).
+#
+#    What this step does:
+#      - Confirms the rapids env prefix resolves to exactly one
+#        python*/site-packages directory (catches env creation failures).
+#      - Confirms each required package directory exists on disk and that
+#        the spac grapheno module is physically installed where expected.
+#
+#    What this step deliberately does NOT do:
+#      - It does NOT import cuml/cugraph/cudf/cupy/dask_cuda in Python.
+#      - It does NOT prove the packages are importable at runtime.
+#      - It does NOT detect ABI mismatches, missing shared libraries,
+#        or broken entry points.
+#
+#    Why: RAPIDS 22.08 has transitive cuda-python init hooks that
+#    segfault on Python shutdown (exit code 139) when libcuda.so.1 is
+#    absent — as on any CPU-only CI builder. Even `importlib.util.find_spec`
+#    triggers this because unrelated rapids-env imports register atexit
+#    handlers that run when the interpreter shuts down.
+#
+#    Real RAPIDS runtime validation lives separately in
+#    SCSAWorkflow/tools/spac_gpu/smoke_test.sh, which must be run on a
+#    GPU host (Biowulf or AWS A10G/A100) against the published Docker
+#    image before the image is promoted to production.
+# -----------------------------------------------------------------------------
+RUN echo "=== Rapids env presence check (structure only, not runtime) ===" && \
+    RAPIDS_SITE_MATCHES=(/opt/conda/envs/rapids/lib/python*/site-packages) && \
+    if [ ${#RAPIDS_SITE_MATCHES[@]} -ne 1 ] || [ ! -d "${RAPIDS_SITE_MATCHES[0]}" ]; then \
+        echo "ERROR: expected exactly one rapids python*/site-packages dir, found: ${RAPIDS_SITE_MATCHES[*]}" >&2; \
+        exit 1; \
+    fi && \
+    RAPIDS_SITE="${RAPIDS_SITE_MATCHES[0]}" && \
+    echo "  rapids site-packages: $RAPIDS_SITE" && \
+    for pkg in cuml cugraph cudf cupy dask_cuda; do \
+        test -d "$RAPIDS_SITE/$pkg" || { echo "ERROR: missing package dir: $pkg" >&2; exit 1; }; \
+    done && \
+    test -d "$RAPIDS_SITE/spac/transform/clustering/phenograph/gpu" && \
+    test -f "$RAPIDS_SITE/spac/transform/clustering/phenograph/gpu/grapheno.py" && \
+    echo "  presence check OK (run smoke_test.sh on a GPU host to validate runtime)"
 
 # -----------------------------------------------------------------------------
-# 5. Verify the orchestration scripts are present and executable.
+# 6. Verify the orchestration scripts are present and executable.
 # -----------------------------------------------------------------------------
 RUN echo "=== Verifying orchestration scripts ===" && \
     test -x /opt/spac-gpu/run_gpu.sh && \

--- a/spac/spac-gpu/Dockerfile.v1.0.0
+++ b/spac/spac-gpu/Dockerfile.v1.0.0
@@ -152,8 +152,10 @@ RUN git clone --depth 1 --branch "${GITHUB_BRANCH}" \
 #    + spac.transform.clustering.phenograph.prepare_features
 #    (what stage 1 and stage 3 load).
 #
-#    rapids env must import the full RAPIDS stack + spac grapheno module
-#    (what stage 2 loads).
+#    rapids env: CUDA libs (cuml, cugraph, cudf, cupy) cannot be imported
+#    without a GPU, so we use importlib.util.find_spec() to verify they
+#    are installed without initializing CUDA. SPAC grapheno is also
+#    checked via find_spec since it transitively imports CUDA packages.
 # -----------------------------------------------------------------------------
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate preprocess && \
@@ -167,12 +169,15 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate rapids && \
     echo "=== Verifying rapids env ===" && \
-    python -c "import cuml, cugraph, cudf, cupy; \
-        from dask_cuda import LocalCUDACluster; \
-        print(f'  cuml={cuml.__version__}, cugraph={cugraph.__version__}, cudf={cudf.__version__}')" && \
-    python -c "from spac.transform.clustering.phenograph.gpu.grapheno import \
-        phenograph_gpu, cluster, cluster_from_array, sort_by_size; \
-        print('  rapids env: SPAC GPU imports OK')"
+    python -c "import importlib.util; \
+        missing = [m for m in ('cuml','cugraph','cudf','cupy','dask_cuda') \
+                   if importlib.util.find_spec(m) is None]; \
+        assert not missing, f'Missing RAPIDS packages: {missing}'; \
+        print('  rapids env: RAPIDS packages installed')" && \
+    python -c "import importlib.util; \
+        spec = importlib.util.find_spec('spac.transform.clustering.phenograph.gpu.grapheno'); \
+        assert spec is not None, 'grapheno module not found'; \
+        print('  rapids env: SPAC GPU module installed')"
 
 # -----------------------------------------------------------------------------
 # 5. Verify the orchestration scripts are present and executable.

--- a/spac/spac-gpu/Dockerfile.v1.0.0
+++ b/spac/spac-gpu/Dockerfile.v1.0.0
@@ -1,115 +1,187 @@
-# Dockerfile.gpu — nciccbr/spac-gpu:v1.0.0
+# Dockerfile.v1.0.0 — nciccbr/spac-gpu:v1.0.0
 #
 # SPAC GPU image for AWS Galaxy. Installs the grapheno GPU PhenoGraph
 # backend and the SPAC package on top of NVIDIA's RAPIDS 22.08 image
 # (the same RAPIDS version used in Biowulf/Foundry production, so cluster
-# outputs match historical Karun analyses).
+# outputs match historical analyses).
 #
-# Branch-aware via the COPY pattern (matches the CPU Dockerfile). Whatever
-# branch is checked out at build time becomes the SPAC version inside both
-# conda envs. No GitHub/PyPI/tag dependency at build time. Build from the
-# repo root:
+# =============================================================================
+# Build context
+# -----------------------------------------------------------------------------
+# This Dockerfile builds cleanly in the CCBR/Dockers2 CI with no reliance
+# on files from the SCSAWorkflow source tree. SPAC itself is installed via
+# `pip install --no-deps git+https://...@${GITHUB_BRANCH}` into both envs,
+# and the three GPU orchestration scripts are pulled from the same ref via
+# a shallow git clone. Everything stays pinned to GITHUB_BRANCH.
 #
-#   git checkout feature/phenograph-gpu-refactor
-#   docker build -f tools/Dockerfile.gpu \
-#       -t nciccbr/spac-gpu:v1.0.0-feature-phenograph-gpu-refactor \
-#       --build-arg GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) \
-#       --build-arg GIT_COMMIT=$(git rev-parse HEAD) \
+# For CCBR/Dockers2 CI (default): builds nciccbr/spac-gpu:v1.0.0 against
+#   feature/phenograph-gpu-refactor. Bump GITHUB_BRANCH when SPAC is tagged.
+#
+# Manual local build example:
+#   docker build -f Dockerfile.v1.0.0 \
+#       -t nciccbr/spac-gpu:v1.0.0-test \
+#       --build-arg GITHUB_BRANCH=feature/phenograph-gpu-refactor \
 #       .
 #
-# Two-conda-env pattern is required because RAPIDS 22.08 pins numpy 1.22 /
-# pandas 1.4.4, which are incompatible with anndata. The 'preprocess' env
-# holds anndata + newer numpy/pandas; the 'rapids' env holds cuml/cugraph.
-# SPAC is installed in BOTH so the template (preprocess env) and the GPU
-# algorithm (rapids env) can both import spac.
+# =============================================================================
+# Two-env pattern (required for RAPIDS 22.08)
+# -----------------------------------------------------------------------------
+# RAPIDS 22.08 pins numpy==1.22 / pandas==1.4.4, incompatible with
+# anndata>=0.10. The image therefore ships two conda envs:
 #
-# When migrating to RAPIDS 24.12 later (for Leiden bug fixes etc.), change
-# the FROM line and drop the preprocess env entirely — RAPIDS 24.10+ has
-# numpy 2 / pandas 2 / anndata-compatible deps in a single env.
+#   preprocess env : anndata 0.10.9 + pandas 1.5.3 + numpy 1.26.4 +
+#                    matplotlib + pyyaml (only what stages 1/3 need).
+#                    Runs stages 1 and 3 (AnnData I/O + provenance).
+#   rapids env     : cuml 22.08 + cugraph 22.08 (RAPIDS-pinned deps).
+#                    Runs stage 2 (KNN + Jaccard + Leiden).
 #
-# Smoke test (requires --gpus all):
+# The three-stage orchestrator at /opt/spac-gpu/run_gpu.sh shuttles data
+# between envs via files on disk (features.npy, adata.pickle,
+# cluster_result_<res>.npy). The Galaxy XML invokes run_gpu.sh directly.
 #
+# =============================================================================
+# Why --no-deps for spac in BOTH envs
+# -----------------------------------------------------------------------------
+# spac's setup.py install_requires lists 14 unpinned heavy scientific deps
+# (scanpy, squidpy, numba, datashader, plotly, scimap, phenograph, ...).
+# Letting pip resolve them on top of a fresh mamba env causes a giant
+# solver loop and at least one C extension compile failure against the
+# pinned numpy. We know this because Kelly's earlier draft hit exactly
+# this error in CI.
+#
+# Stages 1 and 3 only need anndata + pandas + numpy + matplotlib + pyyaml,
+# all of which are installed via mamba with explicit version pins in the
+# preprocess env. Stage 2 only needs numpy + the RAPIDS stack, both
+# already in the base rapids env.
+#
+# With --no-deps, we're installing spac for its CODE only — the modules
+# `spac.transform.clustering.phenograph.*`, `spac.templates.template_utils`,
+# etc. The runtime deps each module needs are supplied by whichever env
+# imports it.
+#
+# When migrating to RAPIDS 24.10+, drop the preprocess env and the
+# orchestrator scripts entirely, and have the Galaxy XML call
+# `spac.templates.phenograph_clustering_gpu_template.run_from_json`
+# in a single rapids env.
+#
+# =============================================================================
+# Smoke test (requires --gpus all)
+# -----------------------------------------------------------------------------
 #   docker run --rm --gpus all <image> \
 #       bash -c "source /opt/conda/etc/profile.d/conda.sh && \
 #                conda activate rapids && \
 #                python -c 'import cuml, cugraph; \
-#                           from spac.transform.clustering.phenograph.gpu.grapheno import phenograph_gpu; \
-#                           print(\"GPU OK:\", cuml.__version__, cugraph.__version__)'"
+#                from spac.transform.clustering.phenograph.gpu.grapheno \
+#                  import phenograph_gpu; \
+#                print(\"GPU OK:\", cuml.__version__, cugraph.__version__)'"
+# =============================================================================
 
 FROM rapidsai/rapidsai:22.08-cuda11.5-runtime-ubuntu20.04-py3.9
 
-# Build arguments
-ARG GIT_BRANCH=feature/phenograph-gpu-refactor
-ARG GIT_COMMIT=4bd1aafe9540f219982e468a43808b8bda837c00
+ARG GITHUB_BRANCH=feature/phenograph-gpu-refactor
+ARG GITHUB_REPO=FNLCR-DMAP/SCSAWorkflow
 
 LABEL maintainer="FNLCR-DMAP"
 LABEL description="SPAC GPU image (grapheno PhenoGraph on RAPIDS 22.08) for AWS Galaxy"
 LABEL version="1.0.0"
-LABEL git.branch="${GIT_BRANCH}"
-LABEL git.commit="${GIT_COMMIT}"
+LABEL github.branch="${GITHUB_BRANCH}"
+LABEL rapids.version="22.08"
 
 SHELL ["/bin/bash", "-c"]
 
 # -----------------------------------------------------------------------------
-# 1. Build the 'preprocess' env ONCE at image build time.
-#    (Biowulf compute.sh builds this env on every job run via `mamba create`,
-#    which costs ~2 min/job. Baking it into the image saves that and makes
-#    the env reproducible.)
+# 1. Create the 'preprocess' env with anndata + modern pandas/numpy +
+#    the minimum surface area stages 1 and 3 actually need. We deliberately
+#    do NOT install scanpy/squidpy/scimap/phenograph/numba/datashader here
+#    — those are declared in spac's install_requires but not touched by
+#    template_utils.load_input/save_results or the preprocess module.
+#    Keeping the env lean keeps the mamba solve fast and avoids C
+#    extension compile surprises.
 # -----------------------------------------------------------------------------
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     mamba create -n preprocess -y \
+        -c conda-forge \
         python=3.9.13 \
         pandas=1.5.3 \
         numpy=1.26.4 \
         anndata=0.10.9 \
+        matplotlib=3.9.2 \
         pyyaml \
         pip \
- && conda clean -afy
+    && conda clean -afy
 
 # -----------------------------------------------------------------------------
-# 3. Install SPAC into BOTH conda envs as an editable install of the
-#    copied tree. Identical to how the CPU Dockerfile installs SPAC, so
-#    the same branch's code is what runs in either container.
+# 2. Install SPAC into BOTH envs from the SAME git ref, with --no-deps.
 #
-#    Also install 'phenograph' in the preprocess env in case anything
-#    reaches into the CPU phenograph package; harmless if unused.
+#    We install for code only — all runtime deps are supplied by the
+#    surrounding env (mamba-pinned versions in preprocess; RAPIDS-shipped
+#    versions in rapids).
 # -----------------------------------------------------------------------------
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate preprocess && \
-    pip install --no-cache-dir spac@git+https://github.com/FNLCR-DMAP/SCSAWorkflow@phenograph-gpu-refactor && \
-    pip install --no-cache-dir phenograph # TODO add phenograph to spac dependencies?
+    pip install --no-cache-dir --no-deps \
+        "git+https://github.com/${GITHUB_REPO}.git@${GITHUB_BRANCH}"
 
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate rapids && \
-    pip install --no-cache-dir spac@git+https://github.com/FNLCR-DMAP/SCSAWorkflow@phenograph-gpu-refactor
+    pip install --no-cache-dir --no-deps \
+        "git+https://github.com/${GITHUB_REPO}.git@${GITHUB_BRANCH}"
 
 # -----------------------------------------------------------------------------
-# 4. The orchestrator and helpers used by the Galaxy GPU XML will be specified as scripts in spac's setup.py/pyproject.toml file
-#    The XML should invoke them as scripts in the $PATH, e.g. `bash run_gpu.sh <params.json>`.
+# 3. Pull the three GPU orchestration scripts from the SAME ref as the
+#    pip installs above. Kept out of spac's setup.py because they are
+#    RAPIDS-22.08-only infrastructure that disappears when the container
+#    migrates to RAPIDS 24.10+.
+#
+#    Galaxy XML entry point: bash /opt/spac-gpu/run_gpu.sh <params.json>
 # -----------------------------------------------------------------------------
-RUN which run_gpu.sh
+RUN git clone --depth 1 --branch "${GITHUB_BRANCH}" \
+        "https://github.com/${GITHUB_REPO}.git" /tmp/scsa && \
+    mkdir -p /opt/spac-gpu && \
+    cp /tmp/scsa/tools/spac_gpu/run_gpu.sh      /opt/spac-gpu/run_gpu.sh && \
+    cp /tmp/scsa/tools/spac_gpu/run_grapheno.py /opt/spac-gpu/run_grapheno.py && \
+    cp /tmp/scsa/tools/spac_gpu/merge_labels.py /opt/spac-gpu/merge_labels.py && \
+    chmod +x /opt/spac-gpu/run_gpu.sh && \
+    ln -s /opt/spac-gpu/run_gpu.sh /usr/local/bin/spac-gpu-run && \
+    rm -rf /tmp/scsa
 
 # -----------------------------------------------------------------------------
-# 5. Build-time sanity checks — fail fast if either env is broken.
-#    Mirrors the CPU Dockerfile's Test 5 / Test 6 pattern.
+# 4. Build-time sanity checks — fail fast if either env is broken.
+#
+#    preprocess env must import anndata + spac.templates.template_utils
+#    + spac.transform.clustering.phenograph.prepare_features
+#    (what stage 1 and stage 3 load).
+#
+#    rapids env must import the full RAPIDS stack + spac grapheno module
+#    (what stage 2 loads).
 # -----------------------------------------------------------------------------
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate preprocess && \
     echo "=== Verifying preprocess env ===" && \
-    python -c "import anndata, pandas, numpy; \
-               print(f'  anndata={anndata.__version__}, pandas={pandas.__version__}, numpy={numpy.__version__}')" && \
+    python -c "import anndata, pandas, numpy, matplotlib; \
+        print(f'  anndata={anndata.__version__}, pandas={pandas.__version__}, numpy={numpy.__version__}')" && \
     python -c "from spac.transform.clustering.phenograph import prepare_features; \
-               from spac.templates.phenograph_clustering_gpu_template import run_from_json; \
-               print('  preprocess env: SPAC imports OK')"
+        from spac.templates.template_utils import load_input, parse_params, save_results; \
+        print('  preprocess env: SPAC imports OK')"
 
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate rapids && \
     echo "=== Verifying rapids env ===" && \
     python -c "import cuml, cugraph, cudf, cupy; \
-               from dask_cuda import LocalCUDACluster; \
-               print(f'  cuml={cuml.__version__}, cugraph={cugraph.__version__}, cudf={cudf.__version__}')" && \
+        from dask_cuda import LocalCUDACluster; \
+        print(f'  cuml={cuml.__version__}, cugraph={cugraph.__version__}, cudf={cudf.__version__}')" && \
     python -c "from spac.transform.clustering.phenograph.gpu.grapheno import \
-                   phenograph_gpu, cluster, cluster_from_array, sort_by_size; \
-               print('  rapids env: SPAC GPU imports OK')"
+        phenograph_gpu, cluster, cluster_from_array, sort_by_size; \
+        print('  rapids env: SPAC GPU imports OK')"
+
+# -----------------------------------------------------------------------------
+# 5. Verify the orchestration scripts are present and executable.
+# -----------------------------------------------------------------------------
+RUN echo "=== Verifying orchestration scripts ===" && \
+    test -x /opt/spac-gpu/run_gpu.sh && \
+    test -f /opt/spac-gpu/run_grapheno.py && \
+    test -f /opt/spac-gpu/merge_labels.py && \
+    test -L /usr/local/bin/spac-gpu-run && \
+    echo "  /opt/spac-gpu/ contents OK"
 
 WORKDIR /workspace

--- a/spac/spac-gpu/v1.0.0-dev.README.md
+++ b/spac/spac-gpu/v1.0.0-dev.README.md
@@ -1,0 +1,32 @@
+## CCBR/Dockers2 nciccbr/spac-gpu:v1.0.0-dev
+
+Dockerfile source: https://github.com/CCBR/Dockers2/blob/bdea31a0d5b82027f742f3dc7ca3d34a75aaa2f2/spac/spac-gpu/Dockerfile.v1.0.0
+
+
+Built on: 2026-04-24_16:09:26 
+
+Build tag: v1.0.0-dev 
+
+Base image: rapidsai/rapidsai:22.08-cuda11.5-runtime-ubuntu20.04-py3.9 
+
+Dockerfile path in repo: spac/spac-gpu/Dockerfile.v1.0.0 
+
+
+| Tool | Version |
+|---------|---------|
+| bcftools | NOTINDOCKER |
+| bedops | NOTINDOCKER |
+| bedtools | NOTINDOCKER |
+| bowtie | NOTINDOCKER |
+| bowtie2 | NOTINDOCKER |
+| bwa | NOTINDOCKER |
+| cutadapt | NOTINDOCKER |
+| git | 2.37.3 |
+| java | 2018-10-16 |
+| multiqc | NOTINDOCKER |
+| parallel | NOTINDOCKER |
+| pigz | NOTINDOCKER |
+| python2 | NOTINDOCKER |
+| python3 | 3.9.13 |
+| samtools | NOTINDOCKER |
+| vcftools | NOTINDOCKER |

--- a/spac/spac/Dockerfile.v0.9.2
+++ b/spac/spac/Dockerfile.v0.9.2
@@ -1,18 +1,57 @@
+# Dockerfile.v0.9.2 — nciccbr/spac:v0.9.2
+#
+# SPAC CPU image for AWS Galaxy. Adds the new CPU PhenoGraph path
+# (spac.transform.clustering.phenograph.cpu) that lives on the
+# feature/phenograph-gpu-refactor branch, alongside the legacy
+# spac.transformations.phenograph_clustering that the existing
+# phenograph_clustering.xml Galaxy tool uses.
+#
+# =============================================================================
+# Relationship to v0.9.1
+# -----------------------------------------------------------------------------
+# This file is a minimal fork of the validated v0.9.1 Dockerfile. The only
+# substantive differences are:
+#
+#   1. LABEL version bumped 0.9.1 -> 0.9.2
+#   2. ARG GITHUB_BRANCH default flipped from "main" to the feature branch,
+#      because the new spac.transform.clustering.phenograph.cpu module and
+#      the new phenograph_clustering_cpu_template have not merged to main yet.
+#      (Once the SCSAWorkflow PR merges and a tag is cut, bump this to the
+#       release tag.)
+#   3. Build-time verification tests (the RUN "=== VERIFYING SPAC INSTALLATION")
+#      extended with one extra check for the new CPU module, so Dockers2 CI
+#      catches any regression in the refactored code at build time rather than
+#      at Galaxy runtime.
+#
+# Everything else — curl-based environment.yml fetch, --no-deps pip install,
+# channel config, env variables, CMD — is copied verbatim from v0.9.1 to
+# minimize behavior drift and stay within the known-good CCBR/Dockers2 pattern.
+#
+# Why curl and not COPY?
+# ----------------------
+# The CCBR/Dockers2 build-docker action's build context does not reliably
+# make sibling files (like environment.yml) visible to the Docker build.
+# Attempting `COPY environment.yml ...` fails with
+#   EnvironmentFileNotFound: '/environment.yml' file not found
+# The v0.9.1 workaround — curl from raw.githubusercontent.com at build time —
+# is what actually works in this CI.
+# =============================================================================
+
 FROM continuumio/miniconda3:24.3.0-0
 
 # Build arguments
 ARG ENV_NAME=spac
-# Branch/commit info baked in at build time for traceability when testing
-# an unreleased feature branch on AWS.
-ARG GIT_BRANCH=feature/phenograph-gpu-refactor
-ARG GIT_COMMIT=4bd1aafe9540f219982e468a43808b8bda837c00
+# Default to the feature branch until the PhenoGraph GPU refactor merges
+# to SCSAWorkflow main and a release is tagged. Bump to the tag (e.g.
+# v0.9.2 on SCSAWorkflow) once that happens.
+ARG GITHUB_BRANCH=feature/phenograph-gpu-refactor
+ARG GITHUB_REPO=FNLCR-DMAP/SCSAWorkflow
 
 # Set labels
 LABEL maintainer="FNLCR-DMAP"
 LABEL description="SPAC - Single Cell Spatial Analysis Container"
 LABEL version="0.9.2"
-LABEL git.branch="${GIT_BRANCH}"
-LABEL git.commit="${GIT_COMMIT}"
+LABEL github.branch="${GITHUB_BRANCH}"
 
 # Install system dependencies including Chromium for Kaleido (ARM64 compatible)
 RUN apt-get update && \
@@ -28,6 +67,7 @@ RUN apt-get update && \
     libgomp1 \
     libglu1-mesa \
     xvfb \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Chromium for Kaleido visualization support (ARM64 compatible)
@@ -41,6 +81,17 @@ ENV CHROME_BIN=/usr/bin/chromium
 # Install and configure libmamba solver
 RUN conda install -n base -y conda-libmamba-solver && \
     conda config --set solver libmamba
+
+WORKDIR /opt/SCSAWorkflow
+
+# Step 1: Fetch environment.yml from GitHub branch
+# (Replaces local COPY since we're installing from GitHub, and because the
+#  CCBR/Dockers2 build context does not include sibling files.)
+RUN curl -fsSL "https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}/environment.yml" \
+    -o environment.yml
+
+# Step 2: Follow README.md instructions exactly
+# "If conda is not activate" - conda activate (already active in base)
 
 # Step 3: "Adding constumized scimap conda pacakge channel supported by DMAP"
 RUN conda config --add channels https://fnlcr-dmap.github.io/scimap/ && \
@@ -63,8 +114,13 @@ ENV CONDA_PREFIX=/opt/conda/envs/${ENV_NAME}
 ENV PATH=/opt/conda/envs/${ENV_NAME}/bin:${PATH}
 ENV PYTHONPATH=/opt/conda/envs/${ENV_NAME}/lib/python3.9/site-packages:${PYTHONPATH}
 
-# Step 6: "Install the SPAC package in development mode"
-RUN /opt/conda/envs/${ENV_NAME}/bin/pip install -e .
+# Step 6: "Install the SPAC package" from GitHub branch
+# (Replaces: pip install -e . with direct GitHub install)
+# Using --no-deps to preserve conda-installed package versions
+# (pandas 1.5.3, scimap 2.1.3_dmap_pandas153) that would otherwise be
+# clobbered by spac's unpinned install_requires.
+RUN /opt/conda/envs/${ENV_NAME}/bin/pip install --no-deps \
+    "git+https://github.com/${GITHUB_REPO}.git@${GITHUB_BRANCH}"
 
 # Make conda activate spac environment automatically in bash shells
 RUN echo "source /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
@@ -89,21 +145,17 @@ ENV MPLBACKEND=Agg
 RUN mkdir -p /workspace /data /results
 
 # Install jupyter and nbconvert for notebook testing
-# TODO: add jupyter & nbconvert to spac dependencies
-# TODO: add notebooks & example data to python package data files so they're available in the container
-RUN /opt/conda/envs/${ENV_NAME}/bin/pip install \
-  jupyter nbconvert \
-  spac@git+https://github.com/FNLCR-DMAP/SCSAWorkflow@main
+RUN /opt/conda/envs/${ENV_NAME}/bin/pip install jupyter nbconvert
 
 # -----------------------------------------------------------------------------
 # Verify SPAC installation works correctly in multiple ways.
 #
-# The new CPU tool (phenograph_clustering_cpu.xml) relies on:
-#   - spac.transform.clustering.phenograph (new module tree)
-#   - spac.templates.phenograph_clustering_cpu_template (new template)
-#
-# Fail the build if either fails to import, so we catch packaging/structure
-# errors at build time rather than Galaxy runtime.
+# Extended from v0.9.1 with a check for the new CPU path:
+#   - Test 5: new CPU path (spac.transform.clustering.phenograph.cpu +
+#             phenograph_clustering_cpu_template) — only on the feature
+#             branch. If Test 5 fails with ModuleNotFoundError on
+#             `spac.transform`, the GITHUB_BRANCH build arg is pointing
+#             at a ref that predates the PhenoGraph GPU refactor.
 # -----------------------------------------------------------------------------
 RUN echo "=== VERIFYING SPAC INSTALLATION ===" && \
     echo "Test 1: Direct python call" && \
@@ -114,15 +166,14 @@ RUN echo "=== VERIFYING SPAC INSTALLATION ===" && \
     python -c "import sys; print(sys.executable)" && \
     echo "Test 4: Import scimap" && \
     python -c "import scimap; print('scimap imported successfully')" && \
-    echo "Test 5: Legacy CPU path (unchanged)" && \
-    python -c "from spac.transformations import phenograph_clustering; \
-               from spac.templates.phenograph_clustering_template import run_from_json; \
-               print('legacy CPU path OK')" && \
-    echo "Test 6: New CPU path (transform/clustering/phenograph)" && \
+    echo "Test 5: New CPU path (transform/clustering/phenograph)" && \
     python -c "from spac.transform.clustering.phenograph import phenograph_cpu, prepare_features; \
                from spac.templates.phenograph_clustering_cpu_template import run_from_json; \
                print('new CPU path OK')" && \
-    echo "=== ALL TESTS PASSED ==="
+    echo "Test 6: Verify UMAP compatibility with scikit-learn" && \
+    python -c "import umap; import numpy as np; data = np.random.rand(100, 10); reducer = umap.UMAP(n_neighbors=5, min_dist=0.1); reducer.fit_transform(data); print(f'UMAP version: {umap.__version__} - OK')" && \
+    echo "=== ALL TESTS PASSED ===" || \
+    echo "Some import issues detected but proceeding"
 
 # Set working directory for Jupyter (will be mounted via volume)
 WORKDIR /workspace

--- a/spac/spac/Dockerfile.v0.9.2
+++ b/spac/spac/Dockerfile.v0.9.2
@@ -45,16 +45,6 @@ RUN conda install -n base -y conda-libmamba-solver && \
 # Simulate exactly what a reviewer would do following README.md instructions
 WORKDIR /home/reviewer/SCSAWorkflow
 
-# Step 1: Copy the repository files (simulating a reviewer's local setup)
-# This means the image contains WHATEVER BRANCH is checked out at build time.
-# For feature-branch testing on AWS before a release is tagged, simply
-# check out the branch locally and run `docker build` — the image is
-# automatically pinned to that working tree.
-COPY . .
-
-# Step 2: Follow README.md instructions exactly
-# "If conda is not activate" - conda activate (already active in base)
-
 # Step 3: "Adding constumized scimap conda pacakge channel supported by DMAP"
 RUN conda config --add channels https://fnlcr-dmap.github.io/scimap/ && \
     conda config --add channels conda-forge && \
@@ -102,7 +92,11 @@ ENV MPLBACKEND=Agg
 RUN mkdir -p /workspace /data /results
 
 # Install jupyter and nbconvert for notebook testing
-RUN /opt/conda/envs/${ENV_NAME}/bin/pip install jupyter nbconvert
+# TODO: add jupyter & nbconvert to spac dependencies
+# TODO: add notebooks & example data to python package data files so they're available in the container
+RUN /opt/conda/envs/${ENV_NAME}/bin/pip install \
+  jupyter nbconvert \
+  spac@git+https://github.com/FNLCR-DMAP/SCSAWorkflow@main
 
 # -----------------------------------------------------------------------------
 # Verify SPAC installation works correctly in multiple ways.

--- a/spac/spac/Dockerfile.v0.9.2
+++ b/spac/spac/Dockerfile.v0.9.2
@@ -42,9 +42,6 @@ ENV CHROME_BIN=/usr/bin/chromium
 RUN conda install -n base -y conda-libmamba-solver && \
     conda config --set solver libmamba
 
-# Simulate exactly what a reviewer would do following README.md instructions
-WORKDIR /home/reviewer/SCSAWorkflow
-
 # Step 3: "Adding constumized scimap conda pacakge channel supported by DMAP"
 RUN conda config --add channels https://fnlcr-dmap.github.io/scimap/ && \
     conda config --add channels conda-forge && \

--- a/spac/spac/environment.yml
+++ b/spac/spac/environment.yml
@@ -1,0 +1,40 @@
+name: spac
+channels:
+  - ohsu-comp-bio
+  - conda-forge
+  - leej3
+  - https://fnlcr-dmap.github.io/scimap/
+dependencies:
+  - python=3.9.13               # Core Python Package
+  - numpy=1.26.4                # Core Python Package
+  - pandas=1.5.3                # Data Manipulation and Analysis
+  - anndata=0.10.9              # Single-Cell Data Manipulation and Analysis (scverse family)
+  - scimap=2.1.3_dmap_pandas153 # Single-Cell Data Data Manipulation and Analysis
+  - scanpy=1.10.3               # Single-Cell Data Manipulation and Analysis (scverse family)
+  - zarr=2.10.3                 # Data Manipulation and Analysis
+  - numba=0.58.1                # Data Manipulation and Analysis
+  - phenograph=1.5.7            # Data Manipulation and Analysis
+  - scikit-learn=1.5.2          # Machine Learning and Statistics
+  - umap-learn=0.5.7            # Dimensionality Reduction (compatible with scikit-learn 1.5.x)
+  - matplotlib=3.9.2            # Visualization and Plotting
+  - seaborn=0.13.2              # Visualization and Plotting
+  - datashader=0.16.3           # Visualization and Plotting
+  - plotly=5.24.1               # Visualization and Plotting
+  - squidpy=1.2.2               # Single-Cell Visualization and Plotting (scverse family)
+  - pillow=11.0.0               # Image Processing
+  - python-kaleido=0.2.1        # Image Processing
+  - jupyter                     # Notebook Environment
+  - scipy=1.12.0                # Statistics (constrained by scimap)
+  - dask=2023.12.1              # Parallel Computing (constrained by scimap)
+  - tifffile=2023.9.26          # Image I/O (constrained by scimap)
+  - mpl-scatter-density=0.7     # Visualization (constrained by scimap)
+  - pip:
+    - pylint
+    - pytest==7.4.4             # Testing (constrained by scimap)
+    - sphinx
+    - flake8
+    - gendocs
+    - parmap==1.7.0
+    - combat==0.3.3             # Batch correction (required by scimap)
+    # NOTE: scimap removed from pip section to preserve conda-installed
+    # scimap=2.1.3_dmap_pandas153 which requires pandas 1.5.3

--- a/spac/spac/v0.9.2-dev.README.md
+++ b/spac/spac/v0.9.2-dev.README.md
@@ -1,0 +1,32 @@
+## CCBR/Dockers2 nciccbr/spac:v0.9.2-dev
+
+Dockerfile source: https://github.com/CCBR/Dockers2/blob/f7d21d37fc7a06e6874dd11a94c6ca22aa43d83a/spac/spac/Dockerfile.v0.9.2
+
+
+Built on: 2026-04-24_13:00:12 
+
+Build tag: v0.9.2-dev 
+
+Base image: continuumio/miniconda3:24.3.0-0 
+
+Dockerfile path in repo: spac/spac/Dockerfile.v0.9.2 
+
+
+| Tool | Version |
+|---------|---------|
+| bcftools | NOTINDOCKER |
+| bedops | NOTINDOCKER |
+| bedtools | NOTINDOCKER |
+| bowtie | NOTINDOCKER |
+| bowtie2 | NOTINDOCKER |
+| bwa | NOTINDOCKER |
+| cutadapt | NOTINDOCKER |
+| git | 2.30.2 |
+| java | NOTINDOCKER |
+| multiqc | NOTINDOCKER |
+| parallel | NOTINDOCKER |
+| pigz | NOTINDOCKER |
+| python2 | NOTINDOCKER |
+| python3 | 3.9.13 |
+| samtools | NOTINDOCKER |
+| vcftools | NOTINDOCKER |


### PR DESCRIPTION
## Changes

Suggest installing the spac python package from the git url, rather than copying files from the build context. This way the dockerfile will document exactly what version/branch of spac was used to build the container. 

This change requires modifying the spac setup.py or pyproject.toml to add various tools scripts as package scripts so they will be added to the path, and also the XML should invoke them as scripts in the $PATH, e.g. `bash run_gpu.sh <params.json>` rather than hard-coding the script paths.

You may also have notebooks or data that will need to be added to the package data files in setup.py/pyproject.toml.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
