### PR TITLE
Add SPAC PhenoGraph patch Dockerfiles

### DIFF
--- a/spac/spac-gpu/Dockerfile.v1.0.1
+++ b/spac/spac-gpu/Dockerfile.v1.0.1
@@ -1,0 +1,218 @@
+# Dockerfile.v1.0.1 — nciccbr/spac-gpu:v1.0.1
+#
+# SPAC GPU image for AWS Galaxy. Installs the grapheno GPU PhenoGraph
+# backend and the SPAC package on top of NVIDIA's RAPIDS 22.08 image
+# (the same RAPIDS version used in Biowulf/Foundry production, so cluster
+# outputs match historical analyses).
+#
+# =============================================================================
+# Build context
+# -----------------------------------------------------------------------------
+# This Dockerfile builds cleanly in the CCBR/Dockers2 CI with no reliance
+# on files from the SCSAWorkflow source tree. SPAC itself is installed via
+# `pip install --no-deps git+https://...@${GITHUB_BRANCH}` into both envs,
+# and the three GPU orchestration scripts are pulled from the same ref via
+# a shallow git clone. Everything stays pinned to GITHUB_BRANCH.
+#
+# For CCBR/Dockers2 CI (default): builds nciccbr/spac-gpu:v1.0.1 against
+#   feature/phenograph-gpu-refactor. Bump GITHUB_BRANCH when SPAC is tagged.
+#
+# Manual local build example:
+#   docker build -f Dockerfile.v1.0.1 \
+#       -t nciccbr/spac-gpu:v1.0.1-test \
+#       --build-arg GITHUB_BRANCH=feature/phenograph-gpu-refactor \
+#       .
+#
+# =============================================================================
+# Two-env pattern (required for RAPIDS 22.08)
+# -----------------------------------------------------------------------------
+# RAPIDS 22.08 pins numpy==1.22 / pandas==1.4.4, incompatible with
+# anndata>=0.10. The image therefore ships two conda envs:
+#
+#   preprocess env : anndata 0.10.9 + pandas 1.5.3 + numpy 1.26.4 +
+#                    matplotlib + pyyaml (only what stages 1/3 need).
+#                    Runs stages 1 and 3 (AnnData I/O + provenance).
+#   rapids env     : cuml 22.08 + cugraph 22.08 (RAPIDS-pinned deps).
+#                    Runs stage 2 (KNN + Jaccard + Leiden).
+#
+# The three-stage orchestrator at /opt/spac-gpu/run_gpu.sh shuttles data
+# between envs via files on disk (features.npy, adata.pickle,
+# cluster_result_<res>.npy). The Galaxy XML invokes run_gpu.sh directly.
+#
+# =============================================================================
+# Why --no-deps for spac in BOTH envs
+# -----------------------------------------------------------------------------
+# spac's setup.py install_requires lists 14 unpinned heavy scientific deps
+# (scanpy, squidpy, numba, datashader, plotly, scimap, phenograph, ...).
+# Letting pip resolve them on top of a fresh mamba env causes a giant
+# solver loop and at least one C extension compile failure against the
+# pinned numpy. We know this because Kelly's earlier draft hit exactly
+# this error in CI.
+#
+# Stages 1 and 3 only need anndata + pandas + numpy + matplotlib + pyyaml,
+# all of which are installed via mamba with explicit version pins in the
+# preprocess env. Stage 2 only needs numpy + the RAPIDS stack, both
+# already in the base rapids env.
+#
+# With --no-deps, we're installing spac for its CODE only — the modules
+# `spac.transform.clustering.phenograph.*`, `spac.templates.template_utils`,
+# etc. The runtime deps each module needs are supplied by whichever env
+# imports it.
+#
+# When migrating to RAPIDS 24.10+, drop the preprocess env and the
+# orchestrator scripts entirely, and have the Galaxy XML call
+# `spac.templates.phenograph_clustering_gpu_template.run_from_json`
+# in a single rapids env.
+#
+# =============================================================================
+# Smoke test (requires --gpus all)
+# -----------------------------------------------------------------------------
+#   docker run --rm --gpus all <image> \
+#       bash -c "source /opt/conda/etc/profile.d/conda.sh && \
+#                conda activate rapids && \
+#                python -c 'import cuml, cugraph; \
+#                from spac.transform.clustering.phenograph.gpu.grapheno \
+#                  import phenograph_gpu; \
+#                print(\"GPU OK:\", cuml.__version__, cugraph.__version__)'"
+# =============================================================================
+
+FROM rapidsai/rapidsai:22.08-cuda11.5-runtime-ubuntu20.04-py3.9
+
+ARG GITHUB_BRANCH=feature/phenograph-gpu-refactor
+ARG GITHUB_REPO=FNLCR-DMAP/SCSAWorkflow
+
+LABEL maintainer="FNLCR-DMAP"
+LABEL description="SPAC GPU image (grapheno PhenoGraph on RAPIDS 22.08) for AWS Galaxy"
+LABEL version="1.0.1"
+LABEL github.branch="${GITHUB_BRANCH}"
+LABEL rapids.version="22.08"
+
+SHELL ["/bin/bash", "-c"]
+
+# -----------------------------------------------------------------------------
+# 1. Create the 'preprocess' env with anndata + modern pandas/numpy +
+#    the minimum surface area stages 1 and 3 actually need. We deliberately
+#    do NOT install scanpy/squidpy/scimap/phenograph/numba/datashader here
+#    — those are declared in spac's install_requires but not touched by
+#    template_utils.load_input/save_results or the preprocess module.
+#    Keeping the env lean keeps the mamba solve fast and avoids C
+#    extension compile surprises.
+# -----------------------------------------------------------------------------
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    mamba create -n preprocess -y \
+        -c conda-forge \
+        python=3.9.13 \
+        pandas=1.5.3 \
+        numpy=1.26.4 \
+        anndata=0.10.9 \
+        matplotlib=3.9.2 \
+        pyyaml \
+        pip \
+    && conda clean -afy
+
+# -----------------------------------------------------------------------------
+# 2. Install SPAC into BOTH envs from the SAME git ref, with --no-deps.
+#
+#    We install for code only — all runtime deps are supplied by the
+#    surrounding env (mamba-pinned versions in preprocess; RAPIDS-shipped
+#    versions in rapids).
+# -----------------------------------------------------------------------------
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate preprocess && \
+    pip install --no-cache-dir --no-deps \
+        "git+https://github.com/${GITHUB_REPO}.git@${GITHUB_BRANCH}"
+
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate rapids && \
+    pip install --no-cache-dir --no-deps \
+        "git+https://github.com/${GITHUB_REPO}.git@${GITHUB_BRANCH}"
+
+# -----------------------------------------------------------------------------
+# 3. Pull the three GPU orchestration scripts from the SAME ref as the
+#    pip installs above. Kept out of spac's setup.py because they are
+#    RAPIDS-22.08-only infrastructure that disappears when the container
+#    migrates to RAPIDS 24.10+.
+#
+#    Galaxy XML entry point: bash /opt/spac-gpu/run_gpu.sh <params.json>
+# -----------------------------------------------------------------------------
+RUN git clone --depth 1 --branch "${GITHUB_BRANCH}" \
+        "https://github.com/${GITHUB_REPO}.git" /tmp/scsa && \
+    mkdir -p /opt/spac-gpu && \
+    cp /tmp/scsa/tools/spac_gpu/run_gpu.sh      /opt/spac-gpu/run_gpu.sh && \
+    cp /tmp/scsa/tools/spac_gpu/run_grapheno.py /opt/spac-gpu/run_grapheno.py && \
+    cp /tmp/scsa/tools/spac_gpu/merge_labels.py /opt/spac-gpu/merge_labels.py && \
+    chmod +x /opt/spac-gpu/run_gpu.sh && \
+    ln -s /opt/spac-gpu/run_gpu.sh /usr/local/bin/spac-gpu-run && \
+    rm -rf /tmp/scsa
+
+# -----------------------------------------------------------------------------
+# 4. Build-time sanity checks for the preprocess env.
+#
+#    preprocess env must import anndata + spac.templates.template_utils
+#    + spac.transform.clustering.phenograph.prepare_features
+#    (what stage 1 and stage 3 load).
+#
+#    The rapids env is NOT exercised via Python here — see section 5.
+# -----------------------------------------------------------------------------
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate preprocess && \
+    echo "=== Verifying preprocess env ===" && \
+    python -c "import anndata, pandas, numpy, matplotlib; \
+        print(f'  anndata={anndata.__version__}, pandas={pandas.__version__}, numpy={numpy.__version__}')" && \
+    python -c "from spac.transform.clustering.phenograph import prepare_features; \
+        from spac.templates.template_utils import load_input, parse_params, save_results; \
+        print('  preprocess env: SPAC imports OK')"
+
+# -----------------------------------------------------------------------------
+# 5. STRUCTURE / PRESENCE CHECK for the rapids env (NOT a runtime
+#    validation of RAPIDS itself).
+#
+#    What this step does:
+#      - Confirms the rapids env prefix resolves to exactly one
+#        python*/site-packages directory (catches env creation failures).
+#      - Confirms each required package directory exists on disk and that
+#        the spac grapheno module is physically installed where expected.
+#
+#    What this step deliberately does NOT do:
+#      - It does NOT import cuml/cugraph/cudf/cupy/dask_cuda in Python.
+#      - It does NOT prove the packages are importable at runtime.
+#      - It does NOT detect ABI mismatches, missing shared libraries,
+#        or broken entry points.
+#
+#    Why: RAPIDS 22.08 has transitive cuda-python init hooks that
+#    segfault on Python shutdown (exit code 139) when libcuda.so.1 is
+#    absent — as on any CPU-only CI builder. Even `importlib.util.find_spec`
+#    triggers this because unrelated rapids-env imports register atexit
+#    handlers that run when the interpreter shuts down.
+#
+#    Real RAPIDS runtime validation lives separately in
+#    SCSAWorkflow/tools/spac_gpu/smoke_test.sh, which must be run on a
+#    GPU host (Biowulf or AWS A10G/A100) against the published Docker
+#    image before the image is promoted to production.
+# -----------------------------------------------------------------------------
+RUN echo "=== Rapids env presence check (structure only, not runtime) ===" && \
+    RAPIDS_SITE_MATCHES=(/opt/conda/envs/rapids/lib/python*/site-packages) && \
+    if [ ${#RAPIDS_SITE_MATCHES[@]} -ne 1 ] || [ ! -d "${RAPIDS_SITE_MATCHES[0]}" ]; then \
+        echo "ERROR: expected exactly one rapids python*/site-packages dir, found: ${RAPIDS_SITE_MATCHES[*]}" >&2; \
+        exit 1; \
+    fi && \
+    RAPIDS_SITE="${RAPIDS_SITE_MATCHES[0]}" && \
+    echo "  rapids site-packages: $RAPIDS_SITE" && \
+    for pkg in cuml cugraph cudf cupy dask_cuda; do \
+        test -d "$RAPIDS_SITE/$pkg" || { echo "ERROR: missing package dir: $pkg" >&2; exit 1; }; \
+    done && \
+    test -d "$RAPIDS_SITE/spac/transform/clustering/phenograph/gpu" && \
+    test -f "$RAPIDS_SITE/spac/transform/clustering/phenograph/gpu/grapheno.py" && \
+    echo "  presence check OK (run smoke_test.sh on a GPU host to validate runtime)"
+
+# -----------------------------------------------------------------------------
+# 6. Verify the orchestration scripts are present and executable.
+# -----------------------------------------------------------------------------
+RUN echo "=== Verifying orchestration scripts ===" && \
+    test -x /opt/spac-gpu/run_gpu.sh && \
+    test -f /opt/spac-gpu/run_grapheno.py && \
+    test -f /opt/spac-gpu/merge_labels.py && \
+    test -L /usr/local/bin/spac-gpu-run && \
+    echo "  /opt/spac-gpu/ contents OK"
+
+WORKDIR /workspace

--- a/spac/spac/Dockerfile.v0.9.3
+++ b/spac/spac/Dockerfile.v0.9.3
@@ -1,0 +1,174 @@
+# Dockerfile.v0.9.3 — nciccbr/spac:v0.9.3
+#
+# SPAC CPU image for AWS Galaxy. Adds the new CPU PhenoGraph path
+# (spac.transform.clustering.phenograph.cpu) that lives on the
+# feature/phenograph-gpu-refactor branch, alongside the legacy
+# spac.transformations.phenograph_clustering that the existing
+# phenograph_clustering.xml Galaxy tool uses.
+#
+# =============================================================================
+# Relationship to v0.9.2
+# -----------------------------------------------------------------------------
+# This file is a minimal patch fork of the validated v0.9.2 Dockerfile. The only
+# substantive differences are:
+#
+#   1. LABEL version bumped 0.9.2 -> 0.9.3
+#   2. GITHUB_BRANCH remains on feature/phenograph-gpu-refactor so the image
+#      picks up the PhenoGraph CPU wrapper fix for NumPy community labels.
+#
+# Everything else — curl-based environment.yml fetch, --no-deps pip install,
+# channel config, env variables, CMD — is copied verbatim from v0.9.2 to
+# minimize behavior drift and stay within the known-good CCBR/Dockers2 pattern.
+#
+# Why curl and not COPY?
+# ----------------------
+# The CCBR/Dockers2 build-docker action's build context does not reliably
+# make sibling files (like environment.yml) visible to the Docker build.
+# Attempting `COPY environment.yml ...` fails with
+#   EnvironmentFileNotFound: '/environment.yml' file not found
+# The v0.9.1 workaround — curl from raw.githubusercontent.com at build time —
+# is what actually works in this CI.
+# =============================================================================
+
+FROM continuumio/miniconda3:24.3.0-0
+
+# Build arguments
+ARG ENV_NAME=spac
+# Default to the feature branch until the PhenoGraph GPU refactor merges
+# to SCSAWorkflow main and a release is tagged. Bump to the tag (e.g.
+# v0.9.3 on SCSAWorkflow) once that happens.
+ARG GITHUB_BRANCH=feature/phenograph-gpu-refactor
+ARG GITHUB_REPO=FNLCR-DMAP/SCSAWorkflow
+
+# Set labels
+LABEL maintainer="FNLCR-DMAP"
+LABEL description="SPAC - Single Cell Spatial Analysis Container"
+LABEL version="0.9.3"
+LABEL github.branch="${GITHUB_BRANCH}"
+
+# Install system dependencies including Chromium for Kaleido (ARM64 compatible)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    build-essential \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender-dev \
+    libgomp1 \
+    libglu1-mesa \
+    xvfb \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Chromium for Kaleido visualization support (ARM64 compatible)
+RUN apt-get update && \
+    apt-get install -y chromium && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set Chrome binary path for Kaleido
+ENV CHROME_BIN=/usr/bin/chromium
+
+# Install and configure libmamba solver
+RUN conda install -n base -y conda-libmamba-solver && \
+    conda config --set solver libmamba
+
+WORKDIR /opt/SCSAWorkflow
+
+# Step 1: Fetch environment.yml from GitHub branch
+# (Replaces local COPY since we're installing from GitHub, and because the
+#  CCBR/Dockers2 build context does not include sibling files.)
+RUN curl -fsSL "https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_BRANCH}/environment.yml" \
+    -o environment.yml
+
+# Step 2: Follow README.md instructions exactly
+# "If conda is not activate" - conda activate (already active in base)
+
+# Step 3: "Adding constumized scimap conda pacakge channel supported by DMAP"
+RUN conda config --add channels https://fnlcr-dmap.github.io/scimap/ && \
+    conda config --add channels conda-forge && \
+    conda config --add channels ohsu-comp-bio && \
+    conda config --add channels leej3 && \
+    conda config --add channels bioconda
+
+# Step 4: "Create the Conda environment from environment.yml"
+# Set SSL verification to false for problematic channels
+RUN conda config --set ssl_verify false && \
+    conda env create -f environment.yml && \
+    conda clean -afy && \
+    conda config --set ssl_verify true
+
+# Step 5: Make the environment available (simulate "conda activate spac")
+# Set all necessary environment variables for conda activation
+ENV CONDA_DEFAULT_ENV=${ENV_NAME}
+ENV CONDA_PREFIX=/opt/conda/envs/${ENV_NAME}
+ENV PATH=/opt/conda/envs/${ENV_NAME}/bin:${PATH}
+ENV PYTHONPATH=/opt/conda/envs/${ENV_NAME}/lib/python3.9/site-packages:${PYTHONPATH}
+
+# Step 6: "Install the SPAC package" from GitHub branch
+# (Replaces: pip install -e . with direct GitHub install)
+# Using --no-deps to preserve conda-installed package versions
+# (pandas 1.5.3, scimap 2.1.3_dmap_pandas153) that would otherwise be
+# clobbered by spac's unpinned install_requires.
+RUN /opt/conda/envs/${ENV_NAME}/bin/pip install --no-deps \
+    "git+https://github.com/${GITHUB_REPO}.git@${GITHUB_BRANCH}"
+
+# Make conda activate spac environment automatically in bash shells
+RUN echo "source /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate ${ENV_NAME}" >> ~/.bashrc
+
+# Create a wrapper script that ensures conda environment is activated
+# This helps when Galaxy runs commands directly
+RUN echo '#!/bin/bash' > /usr/local/bin/conda-run && \
+    echo 'source /opt/conda/etc/profile.d/conda.sh' >> /usr/local/bin/conda-run && \
+    echo 'conda activate spac' >> /usr/local/bin/conda-run && \
+    echo 'exec "$@"' >> /usr/local/bin/conda-run && \
+    chmod +x /usr/local/bin/conda-run
+
+# Set the shell to use bash for RUN commands
+SHELL ["/bin/bash", "-c"]
+
+# Set environment variables for headless notebook execution
+ENV QT_QPA_PLATFORM=offscreen
+ENV MPLBACKEND=Agg
+
+# Create working directories for volume mapping
+RUN mkdir -p /workspace /data /results
+
+# Install jupyter and nbconvert for notebook testing
+RUN /opt/conda/envs/${ENV_NAME}/bin/pip install jupyter nbconvert
+
+# -----------------------------------------------------------------------------
+# Verify SPAC installation works correctly in multiple ways.
+#
+# Extended from v0.9.1 with a check for the new CPU path:
+#   - Test 5: new CPU path (spac.transform.clustering.phenograph.cpu +
+#             phenograph_clustering_cpu_template) — only on the feature
+#             branch. If Test 5 fails with ModuleNotFoundError on
+#             `spac.transform`, the GITHUB_BRANCH build arg is pointing
+#             at a ref that predates the PhenoGraph GPU refactor.
+# -----------------------------------------------------------------------------
+RUN echo "=== VERIFYING SPAC INSTALLATION ===" && \
+    echo "Test 1: Direct python call" && \
+    python -c "import spac; print(f'SPAC version: {spac.__version__}')" && \
+    echo "Test 2: Which python" && \
+    which python && \
+    echo "Test 3: Python path" && \
+    python -c "import sys; print(sys.executable)" && \
+    echo "Test 4: Import scimap" && \
+    python -c "import scimap; print('scimap imported successfully')" && \
+    echo "Test 5: New CPU path (transform/clustering/phenograph)" && \
+    python -c "from spac.transform.clustering.phenograph import phenograph_cpu, prepare_features; \
+               from spac.templates.phenograph_clustering_cpu_template import run_from_json; \
+               print('new CPU path OK')" && \
+    echo "Test 6: Verify UMAP compatibility with scikit-learn" && \
+    python -c "import umap; import numpy as np; data = np.random.rand(100, 10); reducer = umap.UMAP(n_neighbors=5, min_dist=0.1); reducer.fit_transform(data); print(f'UMAP version: {umap.__version__} - OK')" && \
+    echo "=== ALL TESTS PASSED ==="
+
+# Set working directory for Jupyter (will be mounted via volume)
+WORKDIR /workspace
+
+# Default command starts Jupyter notebook server
+CMD ["/opt/conda/envs/spac/bin/jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--NotebookApp.token=", "--NotebookApp.password="]


### PR DESCRIPTION
## Summary
- Add `spac/spac/Dockerfile.v0.9.3` for `nciccbr/spac:v0.9.3`.
- Add `spac/spac-gpu/Dockerfile.v1.0.1` for `nciccbr/spac-gpu:v1.0.1`.
- Patch images pull from `FNLCR-DMAP/SCSAWorkflow@feature/phenograph-gpu-refactor`, which now includes fixes for the CPU categorical assignment, GPU orchestrator conda activation, Galaxy GPU XML command formatting, and lazy `anndata` imports in `template_utils`.
- CPU Dockerfile verification now fails the build on import/check failures instead of masking them with a fallback `echo`.

## Validation
SCSAWorkflow focused checks passed before creating these Dockerfiles:
- `python -m pytest tests/templates/test_template_utils_lazy_import.py tests/templates/test_template_utils.py tests/test_transform/clustering/phenograph/test_cpu.py`
- Galaxy CPU/GPU XML parse check
- `bash -n tools/spac_gpu/run_gpu.sh`

## Notes
The corresponding SCSAWorkflow branch is `fix/phenograph-galaxy-runtime-fixes` in `FNLCR-DMAP/SCSAWorkflow`.